### PR TITLE
Reset slide index when loading new decks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4615,9 +4615,16 @@ function wrapSlideshowFor16x9() {
     await buildSlidesFromXMLDoc();
     await applyTheme(theme);
 
-    const visibleIndex = resolveVisibleIndexForAbsolute(state.currentAbsoluteSlideIndex);
+    const requestedIndex = Number.isFinite(Number(options.slideIndex))
+      ? Math.trunc(Number(options.slideIndex))
+      : 0;
+    const maxIndex = Math.max(0, state.slideEls.length - 1);
+    const targetAbsIndex = Math.max(0, Math.min(requestedIndex, maxIndex));
+    state.currentAbsoluteSlideIndex = targetAbsIndex;
+
+    const visibleIndex = resolveVisibleIndexForAbsolute(targetAbsIndex);
     if (state.editMode) {
-      showSlide(state.currentAbsoluteSlideIndex, false);
+      showSlide(targetAbsIndex, false);
     } else {
       showSlide(visibleIndex, true);
     }


### PR DESCRIPTION
## Summary
- clamp the requested slide index during initialization so new or loaded decks always start on their intended first slide

## Testing
- Manual Playwright scenario: open an existing deck, navigate to a later slide, then load a new deck and verify it opens on slide 1


------
https://chatgpt.com/codex/tasks/task_e_68df35536024832685b6eeafdadf634d